### PR TITLE
Add gitignore entries for Eclipse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,13 @@ out/
 # mpeltonen/sbt-idea plugin
 .idea_modules/
 
+# Eclipse
+*.launch
+bin/
+.classpath
+.project
+.settings/
+
 # JIRA plugin
 atlassian-ide-plugin.xml
 


### PR DESCRIPTION
This adds gitignore entries for Eclipse.

I believe some also apply to VSCode, but I don't use it so I just labelled them for Eclipse, below IntelliJ.