### PR TITLE
fix: Cosmetic Preview didn't disable functionality when setting was off

### DIFF
--- a/src/main/java/net/asodev/islandutils/mixins/cosmetics/ChestScreenMixin.java
+++ b/src/main/java/net/asodev/islandutils/mixins/cosmetics/ChestScreenMixin.java
@@ -149,6 +149,7 @@ public abstract class ChestScreenMixin extends Screen {
 
     private void triggerPreviewClicked(int keyCode) {
         if (!MccIslandState.isOnline()) return;
+        if (!IslandOptions.getCosmetics().isShowPlayerPreview()) return;
         if (hoveredSlot == null || !hoveredSlot.hasItem()) return;
         InputConstants.Key previewBind = KeyBindingHelper.getBoundKeyOf(minecraft.options.keyPickItem);
         if (keyCode == previewBind.getValue()) {

--- a/src/main/java/net/asodev/islandutils/mixins/cosmetics/PreviewTutorialMixin.java
+++ b/src/main/java/net/asodev/islandutils/mixins/cosmetics/PreviewTutorialMixin.java
@@ -1,6 +1,7 @@
 package net.asodev.islandutils.mixins.cosmetics;
 
 import net.asodev.islandutils.modules.cosmetics.CosmeticState;
+import net.asodev.islandutils.options.IslandOptions;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.*;
 import net.minecraft.world.entity.player.Player;
@@ -41,6 +42,7 @@ public class PreviewTutorialMixin {
     )
     private void injectedTooltipLines(@Nullable Player player, TooltipFlag tooltipFlag, CallbackInfoReturnable<List<Component>> cir, List<Component> list, MutableComponent mutableComponent) {
         if (CosmeticState.getType((ItemStack)(Object)this) == null) return;
+        if (!IslandOptions.getCosmetics().isShowPlayerPreview()) return;
         list.add(previewComponent);
     }
 


### PR DESCRIPTION
This one is mainly meant to disable the middle-click tooltip and functionality for cosmetic previews when the "Show Cosmetic Previews" setting is off, since it didn't really do that before