### PR TITLE
feature: activity debug ui

### DIFF
--- a/src/main/java/net/asodev/islandutils/IslandUtilsClient.java
+++ b/src/main/java/net/asodev/islandutils/IslandUtilsClient.java
@@ -42,6 +42,7 @@ public class IslandUtilsClient implements ClientModInitializer {
                 GLFW.GLFW_KEY_N, // The keycode of the key
                 "category.islandutils.keys" // The translation key of the keybinding's category.
         ));
+
         SplitManager.init();
         DisguiseUtil.registerDisguiseInput();
         IslandUtilsCommand.register();

--- a/src/main/java/net/asodev/islandutils/discord/DiscordPresenceUpdator.java
+++ b/src/main/java/net/asodev/islandutils/discord/DiscordPresenceUpdator.java
@@ -19,9 +19,12 @@ public class DiscordPresenceUpdator {
     // Discord GameSDK sometimes likes to not work whenever you ask it to do something
     // So we have to be sure we don't crash when that happens.
 
-    @Nullable static Activity activity;
+    @Nullable
+    public static Activity activity;
+
     public static UUID timeLeftBossbar = null;
     public static Instant started;
+
     public static void create() {
         if (!IslandOptions.getDiscord().discordPresence) return;
 

--- a/src/main/java/net/asodev/islandutils/mixins/ui/ActivityDebugMixin.java
+++ b/src/main/java/net/asodev/islandutils/mixins/ui/ActivityDebugMixin.java
@@ -1,0 +1,41 @@
+package net.asodev.islandutils.mixins.ui;
+
+import de.jcm.discordgamesdk.activity.Activity;
+import net.asodev.islandutils.discord.DiscordPresenceUpdator;
+import net.asodev.islandutils.options.IslandOptions;
+import net.asodev.islandutils.state.MccIslandState;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.Gui;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.network.chat.Component;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.List;
+
+@Mixin(Gui.class)
+public class ActivityDebugMixin {
+    @Inject(method = "render", at = @At("TAIL"))
+    private void render(GuiGraphics guiGraphics, float f, CallbackInfo ci) {
+        Activity activity = DiscordPresenceUpdator.activity;
+        if (activity == null
+                || !MccIslandState.isOnline()
+                || !IslandOptions.getMisc().isDebugActivityUi()) return;
+
+        Font font = Minecraft.getInstance().font;
+        List<String> activityPreview = List.of(
+            activity.getDetails(),
+            activity.getState(),
+            String.format("%s [%s]", activity.assets().getSmallText(), activity.assets().getSmallImage()),
+            String.format("%s [%s]", activity.assets().getLargeText(), activity.assets().getLargeImage())
+        );
+
+        guiGraphics.drawString(font, Component.literal("Activity Debug:"), 5, 30, 16777215 | 255 << 24, true);
+        for (String text : activityPreview) {
+            guiGraphics.drawString(font, Component.literal(text), 10, 42 + (9 * activityPreview.indexOf(text)), 16777215 | 255 << 24, true);
+        }
+    }
+}

--- a/src/main/java/net/asodev/islandutils/options/categories/MiscOptions.java
+++ b/src/main/java/net/asodev/islandutils/options/categories/MiscOptions.java
@@ -17,6 +17,7 @@ public class MiscOptions implements OptionsCategory {
     boolean silverPreview = true;
     boolean enableConfigButton = true;
     boolean debugMode = false;
+    boolean debugActivityUi = false;
 
     public boolean isPauseConfirm() {
         return pauseConfirm;
@@ -32,6 +33,10 @@ public class MiscOptions implements OptionsCategory {
     }
     public boolean isDebugMode() {
         return debugMode;
+    }
+
+    public boolean isDebugActivityUi() {
+        return debugActivityUi;
     }
 
     @Override
@@ -66,6 +71,12 @@ public class MiscOptions implements OptionsCategory {
                 .controller(TickBoxControllerBuilder::create)
                 .binding(defaults.debugMode, () -> debugMode, value -> this.debugMode = value)
                 .build();
+        Option<Boolean> debugActivityUiOption = Option.<Boolean>createBuilder()
+                .name(Component.translatable("text.autoconfig.islandutils.option.debugActivityUi"))
+                .description(OptionDescription.of(Component.translatable("text.autoconfig.islandutils.option.debugActivityUi.@Tooltip")))
+                .controller(TickBoxControllerBuilder::create)
+                .binding(defaults.debugActivityUi, () -> debugActivityUi, value -> this.debugActivityUi = value)
+                .build();
 
         return ConfigCategory.createBuilder()
                 .name(Component.literal("Miscellaneous"))
@@ -77,6 +88,7 @@ public class MiscOptions implements OptionsCategory {
                         .name(Component.literal("Debug Options"))
                         .collapsed(true)
                         .option(debugOption)
+                        .option(debugActivityUiOption)
                         .build())
                 .build();
     }

--- a/src/main/resources/assets/island/lang/en_us.json
+++ b/src/main/resources/assets/island/lang/en_us.json
@@ -85,6 +85,8 @@
 
   "text.autoconfig.islandutils.option.debugMode": "Debug Mode",
   "text.autoconfig.islandutils.option.debugMode.@Tooltip": "Enables: Chat debug logs, Custom Item ID tooltips & Other debug features",
+  "text.autoconfig.islandutils.option.debugActivityUi": "Activity Debug UI",
+  "text.autoconfig.islandutils.option.debugActivityUi.@Tooltip": "Adds a debug preview that shows what the Discord Presence displays\nShows: Details, State, Small Text and Image, Large Text and Image",
 
   "modmenu.descriptionTranslation.islandutils": "A Utility Mod for MCC Island!",
   "modmenu.summaryTranslation.islandutils": "A Utility Mod for MCC Island!"

--- a/src/main/resources/islandutils.mixins.json
+++ b/src/main/resources/islandutils.mixins.json
@@ -32,6 +32,7 @@
     "splits.SplitUIMixin",
     "ui.ChatScreenMixin",
     "ui.CommandSuggestionsAccessor",
+    "ui.ActivityDebugMixin",
     "ui.OptionsMixin",
     "ui.PauseScreenMixin"
   ],


### PR DESCRIPTION
When I took a look into MccIslandState, I noticed the events and how underutilized they are considering how powerful they could be.. 

Through this rabbit hole, I've made this activity debug display thing, that displays all the information Discord would show without needing it to have it visible on Discord!
Is it useful? Maybe! Does it look cool? Maybe! Did I make this just because I could? Absolutely yes!

![image](https://github.com/AsoDesu/IslandUtils/assets/24756921/6e82d8f6-9ded-408d-9977-7b046a3936ce)
