### PR TITLE
Add custom reporting screen

### DIFF
--- a/src/main/java/net/asodev/islandutils/IslandUtils.java
+++ b/src/main/java/net/asodev/islandutils/IslandUtils.java
@@ -1,6 +1,7 @@
 package net.asodev.islandutils;
 
 import net.asodev.islandutils.modules.FriendsInGame;
+import net.asodev.islandutils.modules.reporting.ReportHandler;
 import net.asodev.islandutils.options.IslandOptions;
 import net.asodev.islandutils.util.resourcepack.ResourcePackUpdater;
 import net.asodev.islandutils.modules.crafting.state.CraftingItems;
@@ -29,6 +30,7 @@ public class IslandUtils implements ModInitializer {
     public void onInitialize() {
         IslandOptions.init();
         FriendsInGame.init();
+        ReportHandler.init();
 
         Optional<ModContainer> container = FabricLoader.getInstance().getModContainer("islandutils");
         container.ifPresent(modContainer -> version = modContainer.getMetadata().getVersion().getFriendlyString());

--- a/src/main/java/net/asodev/islandutils/mixins/network/PacketListenerMixin.java
+++ b/src/main/java/net/asodev/islandutils/mixins/network/PacketListenerMixin.java
@@ -20,13 +20,12 @@ import net.asodev.islandutils.state.faction.FactionComponents;
 import net.asodev.islandutils.modules.splits.LevelTimer;
 import net.asodev.islandutils.util.ChatUtils;
 import net.asodev.islandutils.util.MusicUtil;
+import net.asodev.islandutils.util.SuggestionProvider;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.multiplayer.ClientPacketListener;
-import net.minecraft.client.multiplayer.ClientSuggestionProvider;
 import net.minecraft.client.resources.sounds.SoundInstance;
 import net.minecraft.commands.CommandSourceStack;
-import net.minecraft.commands.SharedSuggestionProvider;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.Style;
 import net.minecraft.network.chat.TextColor;
@@ -242,6 +241,9 @@ public abstract class PacketListenerMixin {
                     .stream().map(Suggestion::getText) // the text of the suggestions
                     .collect(Collectors.toList()); // a list of the suggestions
             FriendsInGame.setFriends(friends); // Set our friends!
+        }
+        if (SuggestionProvider.invoke(clientboundCommandSuggestionsPacket)) {
+            ci.cancel();
         }
     }
 

--- a/src/main/java/net/asodev/islandutils/mixins/reporting/ChatScreenMixin.java
+++ b/src/main/java/net/asodev/islandutils/mixins/reporting/ChatScreenMixin.java
@@ -1,0 +1,31 @@
+package net.asodev.islandutils.mixins.reporting;
+
+import net.asodev.islandutils.modules.reporting.ReportHandler;
+import net.minecraft.client.gui.screens.ChatScreen;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ChatScreen.class)
+public class ChatScreenMixin {
+
+    @Inject(
+            method = "handleChatInput",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/client/multiplayer/ClientPacketListener;sendCommand(Ljava/lang/String;)V",
+                    shift = At.Shift.BEFORE
+            ),
+            cancellable = true
+    )
+    public void handleChatInput(String string, boolean bl, CallbackInfoReturnable<Boolean> cir) {
+        if (string.startsWith("/report") && ReportHandler.shouldChangeReporting()) {
+            String[] args = string.substring(1).split(" ");
+            if (args.length == 2) {
+                ReportHandler.open(args[1]);
+                cir.setReturnValue(true);
+            }
+        }
+    }
+}

--- a/src/main/java/net/asodev/islandutils/mixins/reporting/MinecraftMixin.java
+++ b/src/main/java/net/asodev/islandutils/mixins/reporting/MinecraftMixin.java
@@ -1,0 +1,31 @@
+package net.asodev.islandutils.mixins.reporting;
+
+import net.asodev.islandutils.modules.reporting.ReportHandler;
+import net.asodev.islandutils.modules.reporting.playersui.ReportingPlayersScreen;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.social.SocialInteractionsScreen;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Minecraft.class)
+public abstract class MinecraftMixin {
+
+    @Shadow public abstract void setScreen(@Nullable Screen screen);
+
+    @Inject(
+        method = "setScreen",
+        at = @At("HEAD"),
+        cancellable = true
+    )
+    private void setScreen(Screen screen, CallbackInfo ci) {
+        if (screen instanceof SocialInteractionsScreen && ReportHandler.shouldChangeReporting()) {
+            setScreen(new ReportingPlayersScreen());
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/java/net/asodev/islandutils/modules/reporting/ReportHandler.java
+++ b/src/main/java/net/asodev/islandutils/modules/reporting/ReportHandler.java
@@ -1,0 +1,79 @@
+package net.asodev.islandutils.modules.reporting;
+
+import net.asodev.islandutils.modules.reporting.reportui.ReportOptionsScreen;
+import net.asodev.islandutils.options.IslandOptions;
+import net.asodev.islandutils.state.MccIslandState;
+import net.asodev.islandutils.util.SuggestionProvider;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ReportHandler {
+
+    private static final List<String> REASONS = new ArrayList<>();
+    private static final List<String> PLAYERS = new ArrayList<>();
+
+    private static Runnable onUpdate = () -> {};
+
+    private static final SuggestionProvider<String> PLAYER_PROVIDER = SuggestionProvider.ofString("/report ")
+            .registerListener(players -> {
+                PLAYERS.clear();
+                PLAYERS.addAll(players);
+                onUpdate.run();
+            });
+    private static final SuggestionProvider<String> REASONS_PROVIDER = SuggestionProvider.ofString("/report test ")
+            .registerListener(reasons -> {
+                REASONS.clear();
+                REASONS.addAll(reasons);
+                PLAYER_PROVIDER.send();
+            });
+
+    private static String deferredReport = null;
+
+    /**
+     * Loads all the required data for the report menu.
+     * <br>
+     * This method is asynchronous and will call the runnable when the all data is loaded.
+     * <br>
+     * Order of loading:
+     * <ol>
+     *     <li>Reasons</li>
+     *     <li>Players</li>
+     *     <li>Runnable</li>
+     * </ol>
+     * @param runnable The runnable to call when the data is loaded.
+     */
+    public static void load(Runnable runnable) {
+        ReportHandler.onUpdate = runnable;
+        REASONS_PROVIDER.send();
+    }
+
+    public static List<String> getReasons() {
+        return REASONS;
+    }
+
+    public static List<String> getPlayers() {
+        return PLAYERS;
+    }
+
+    /**
+     * @return True if the reporting menu should be opened.
+     */
+    public static boolean shouldChangeReporting() {
+        return MccIslandState.isOnline() && IslandOptions.getMisc().isShowReportMenu();
+    }
+
+    public static void init() {
+        ClientTickEvents.END_CLIENT_TICK.register(client -> {
+            if (deferredReport != null) {
+                client.setScreen(new ReportOptionsScreen(deferredReport));
+                deferredReport = null;
+            }
+        });
+    }
+
+    public static void open(String username) {
+        load(() -> deferredReport = username);
+    }
+}

--- a/src/main/java/net/asodev/islandutils/modules/reporting/playersui/ReportingPlayerEntry.java
+++ b/src/main/java/net/asodev/islandutils/modules/reporting/playersui/ReportingPlayerEntry.java
@@ -1,0 +1,80 @@
+package net.asodev.islandutils.modules.reporting.playersui;
+
+import net.asodev.islandutils.modules.reporting.reportui.ReportOptionsScreen;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.*;
+import net.minecraft.client.gui.components.events.GuiEventListener;
+import net.minecraft.client.gui.narration.NarratableEntry;
+import net.minecraft.client.gui.screens.social.PlayerEntry;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+public class ReportingPlayerEntry extends ContainerObjectSelectionList.Entry<ReportingPlayerEntry> {
+
+	private static final ResourceLocation REPORT_BUTTON_LOCATION = new ResourceLocation("textures/gui/report_button.png");
+	private static final Component REPORT_PLAYER_TOOLTIP = Component.translatable("gui.socialInteractions.tooltip.report");
+
+	private final Minecraft minecraft;
+	private final List<AbstractWidget> children;
+	private final String playerName;
+	@Nullable
+	private final Supplier<ResourceLocation> skinGetter;
+	private final Button reportButton;
+	private float tooltipHoverTime;
+
+	public ReportingPlayerEntry(Minecraft minecraft, String name, @Nullable Supplier<ResourceLocation> skinGetter) {
+		this.minecraft = minecraft;
+		this.playerName = name;
+		this.skinGetter = skinGetter;
+		this.reportButton = new ImageButton(
+				0, 0, 20, 20,
+				0, 0, 20,
+				REPORT_BUTTON_LOCATION, 64, 64,
+				button -> minecraft.setScreen(new ReportOptionsScreen(name)),
+				Component.translatable("gui.socialInteractions.report")
+		);
+		this.reportButton.setTooltip(Tooltip.create(REPORT_PLAYER_TOOLTIP, Component.translatable("gui.socialInteractions.narration.report", this.playerName)));
+		this.reportButton.setTooltipDelay(10);
+		this.children = new ArrayList<>();
+		this.children.add(this.reportButton);
+	}
+
+	@Override
+	public void render(GuiGraphics graphics, int index, int top, int left, int width, int height, int mouseX, int mouseY, boolean hovering, float partialTicks) {
+		graphics.fill(left, top, left + width, top + height, PlayerEntry.BG_FILL);
+
+		if (this.skinGetter != null) {
+			PlayerFaceRenderer.draw(graphics, this.skinGetter.get(), left + 4, top + (height - 24) / 2, 24);
+		}
+		graphics.drawString(this.minecraft.font, this.playerName, left + 4 + 24 + 4, top + (height - 9) / 2, PlayerEntry.PLAYERNAME_COLOR, false);
+
+		float hoverTime = this.tooltipHoverTime;
+		this.reportButton.setX(left + (width - this.reportButton.getWidth() - 4));
+		this.reportButton.setY(top + (height - this.reportButton.getHeight()) / 2);
+		this.reportButton.render(graphics, mouseX, mouseY, partialTicks);
+		if (hoverTime == this.tooltipHoverTime) {
+			this.tooltipHoverTime = 0.0F;
+		}
+	}
+
+	@Override
+	public @NotNull List<? extends GuiEventListener> children() {
+		return this.children;
+	}
+
+	@Override
+	public @NotNull List<? extends NarratableEntry> narratables() {
+		return this.children;
+	}
+
+	public String getPlayerName() {
+		return this.playerName;
+	}
+}

--- a/src/main/java/net/asodev/islandutils/modules/reporting/playersui/ReportingPlayersList.java
+++ b/src/main/java/net/asodev/islandutils/modules/reporting/playersui/ReportingPlayersList.java
@@ -1,0 +1,82 @@
+package net.asodev.islandutils.modules.reporting.playersui;
+
+import com.google.common.base.Suppliers;
+import net.minecraft.Optionull;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.ContainerObjectSelectionList;
+import net.minecraft.client.multiplayer.ClientPacketListener;
+import net.minecraft.client.multiplayer.PlayerInfo;
+import net.minecraft.client.resources.DefaultPlayerSkin;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+
+public class ReportingPlayersList extends ContainerObjectSelectionList<ReportingPlayerEntry> {
+
+	private final List<ReportingPlayerEntry> players = new ArrayList<>();
+	@Nullable
+	private String filter;
+
+	public ReportingPlayersList(Minecraft minecraft, int width, int height, int y0, int y1, int itemHeight) {
+		super(minecraft, width, height, y0, y1, itemHeight);
+		this.setRenderBackground(false);
+		this.setRenderTopAndBottom(false);
+	}
+
+	@Override
+	protected void enableScissor(GuiGraphics graphics) {
+		graphics.enableScissor(this.x0, this.y0 + 4, this.x1, this.y1);
+	}
+
+	public void updatePlayerList(Collection<String> collection) {
+		this.addOnlinePlayers(collection);
+		this.updateFiltersAndScroll(this.getScrollAmount());
+	}
+
+	private void addOnlinePlayers(Collection<String> players) {
+		this.players.clear();
+		String self = this.minecraft.getUser().getName();
+		ClientPacketListener connection = this.minecraft.getConnection();
+		if (connection == null) return;
+
+		for (String player : players) {
+			if (player.equalsIgnoreCase(self)) {
+				continue;
+			}
+			PlayerInfo info = connection.getPlayerInfo(player);
+			this.players.add(
+					new ReportingPlayerEntry(
+							this.minecraft, player,
+							Optionull.mapOrDefault(info,
+									i -> i::getSkinLocation,
+									Suppliers.memoize(() -> DefaultPlayerSkin.getDefaultSkin(UUID.randomUUID()))
+							)
+					)
+			);
+		}
+	}
+
+	private void updateFiltersAndScroll(double d) {
+		this.players.sort(Comparator.comparing(ReportingPlayerEntry::getPlayerName, String::compareToIgnoreCase));
+		this.updateFilteredPlayers();
+		this.replaceEntries(this.players);
+		this.setScrollAmount(d);
+	}
+
+	private void updateFilteredPlayers() {
+		if (this.filter != null) {
+			this.players.removeIf(entry -> !entry.getPlayerName().toLowerCase(Locale.ROOT).contains(this.filter));
+			this.replaceEntries(this.players);
+		}
+
+	}
+
+	public void setFilter(@Nullable String string) {
+		this.filter = string;
+	}
+
+	public boolean isEmpty() {
+		return this.players.isEmpty();
+	}
+}

--- a/src/main/java/net/asodev/islandutils/modules/reporting/playersui/ReportingPlayersScreen.java
+++ b/src/main/java/net/asodev/islandutils/modules/reporting/playersui/ReportingPlayersScreen.java
@@ -1,0 +1,123 @@
+package net.asodev.islandutils.modules.reporting.playersui;
+
+import net.asodev.islandutils.modules.reporting.ReportHandler;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.CommonComponents;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.Locale;
+
+public class ReportingPlayersScreen extends Screen {
+
+	public static final ResourceLocation TEXTURE = new ResourceLocation("textures/gui/social_interactions.png");
+
+	private static final Component SEARCH_HINT = Component.translatable("gui.socialInteractions.search_hint").withStyle(ChatFormatting.ITALIC).withStyle(ChatFormatting.GRAY);
+	private static final Component EMPTY_SEARCH = Component.translatable("gui.socialInteractions.search_empty").withStyle(ChatFormatting.GRAY);
+
+	private ReportingPlayersList reportingList = null;
+	private EditBox searchBox;
+	private String lastSearch = "";
+	private boolean initialized;
+
+	public ReportingPlayersScreen() {
+		super(CommonComponents.EMPTY);
+
+		ReportHandler.load(() -> {
+			if (this.reportingList != null) {
+				this.reportingList.updatePlayerList(ReportHandler.getPlayers());
+			}
+		});
+	}
+
+	private int windowHeight() {
+		return Math.max(52, this.height - 128 - 16);
+	}
+
+	private int listEnd() {
+		return 80 + this.windowHeight() - 8;
+	}
+
+	private int marginX() {
+		return (this.width - 238) / 2;
+	}
+
+	@Override
+	public void tick() {
+		super.tick();
+		this.searchBox.tick();
+	}
+
+	@Override
+	protected void init() {
+		if (this.initialized) {
+			this.reportingList.updateSize(this.width, this.height, 88, this.listEnd());
+		} else {
+			this.reportingList = new ReportingPlayersList(this.minecraft, this.width, this.height, 88, this.listEnd(), 36);
+		}
+
+		String string = this.searchBox != null ? this.searchBox.getValue() : "";
+		this.searchBox = new EditBox(this.font, this.marginX() + 29, 75, 198, 13, SEARCH_HINT);
+		this.searchBox.setMaxLength(16);
+		this.searchBox.setVisible(true);
+		this.searchBox.setTextColor(0xFFFFFF);
+		this.searchBox.setValue(string);
+		this.searchBox.setHint(SEARCH_HINT);
+		this.searchBox.setResponder(this::checkSearchStringUpdate);
+		this.addWidget(this.searchBox);
+		this.addWidget(this.reportingList);
+
+		this.initialized = true;
+		this.reportingList.updatePlayerList(ReportHandler.getPlayers());
+	}
+
+	@Override
+	public void renderBackground(GuiGraphics graphics) {
+		super.renderBackground(graphics);
+		graphics.blitNineSliced(TEXTURE, this.marginX() + 3, 64, 236, this.windowHeight() + 16, 8, 236, 34, 1, 1);
+		graphics.blit(TEXTURE, this.marginX() + 13, 76, 243, 1, 12, 12);
+	}
+
+	@Override
+	public void render(GuiGraphics graphics, int mouseX, int mouseY, float partialTicks) {
+		this.renderBackground(graphics);
+
+		graphics.drawString(Minecraft.getInstance().font, "MCC Island - " + this.reportingList.children().size() + " players", this.marginX() + 8, 52, -1);
+
+		if (!this.reportingList.isEmpty()) {
+			this.reportingList.render(graphics, mouseX, mouseY, partialTicks);
+		} else if (!this.searchBox.getValue().isEmpty()) {
+			graphics.drawCenteredString(Minecraft.getInstance().font, EMPTY_SEARCH, this.width / 2, (72 + this.listEnd()) / 2, -1);
+		}
+
+		this.searchBox.render(graphics, mouseX, mouseY, partialTicks);
+		super.render(graphics, mouseX, mouseY, partialTicks);
+	}
+
+	@Override
+	public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
+		if (!this.searchBox.isFocused() && Minecraft.getInstance().options.keySocialInteractions.matches(keyCode, modifiers)) {
+			onClose();
+			return true;
+		}
+		return super.keyPressed(keyCode, scanCode, modifiers);
+	}
+
+	@Override
+	public boolean isPauseScreen() {
+		return false;
+	}
+
+	private void checkSearchStringUpdate(String string) {
+		string = string.toLowerCase(Locale.ROOT);
+		if (!string.equals(this.lastSearch)) {
+			this.reportingList.setFilter(string);
+			this.lastSearch = string;
+			this.reportingList.updatePlayerList(ReportHandler.getPlayers());
+		}
+	}
+}

--- a/src/main/java/net/asodev/islandutils/modules/reporting/reportui/ReportOptionEntry.java
+++ b/src/main/java/net/asodev/islandutils/modules/reporting/reportui/ReportOptionEntry.java
@@ -1,0 +1,57 @@
+package net.asodev.islandutils.modules.reporting.reportui;
+
+import com.mojang.blaze3d.platform.InputConstants;
+import net.minecraft.Util;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.ObjectSelectionList;
+import net.minecraft.network.chat.Component;
+import org.jetbrains.annotations.NotNull;
+
+public class ReportOptionEntry extends ObjectSelectionList.Entry<ReportOptionEntry> {
+
+    private final String reason;
+    private final Component component;
+
+    private final ReportOptionsList list;
+    private final ReportOptionsScreen screen;
+
+    private long lastClickTime;
+
+    public ReportOptionEntry(String reason, ReportOptionsList list, ReportOptionsScreen screen) {
+        this.reason = reason;
+		this.component = Component.translatableWithFallback("report.reason." + reason, reason);
+        this.list = list;
+        this.screen = screen;
+    }
+
+    @Override
+    public void render(GuiGraphics graphics, int index, int top, int left, int width, int height, int mouseX, int mouseY, boolean hovering, float partialTicks) {
+        graphics.drawCenteredString(Minecraft.getInstance().font, this.component, this.list.width() / 2, top + (height - 9) / 2, 0xFFFFFF);
+    }
+
+    @Override
+    public boolean mouseClicked(double mouseX, double mouseY, int button) {
+        if (button == InputConstants.MOUSE_BUTTON_LEFT) {
+            this.list.setSelected(this);
+            if (Util.getMillis() - this.lastClickTime < 250L) {
+                this.screen.complete();
+            }
+
+            this.lastClickTime = Util.getMillis();
+            return true;
+        } else {
+            this.lastClickTime = Util.getMillis();
+            return false;
+        }
+    }
+
+    @Override
+    public @NotNull Component getNarration() {
+        return Component.translatable("narrator.select", this.component);
+    }
+
+    public String reason() {
+        return this.reason;
+    }
+}

--- a/src/main/java/net/asodev/islandutils/modules/reporting/reportui/ReportOptionsList.java
+++ b/src/main/java/net/asodev/islandutils/modules/reporting/reportui/ReportOptionsList.java
@@ -1,0 +1,52 @@
+package net.asodev.islandutils.modules.reporting.reportui;
+
+import net.asodev.islandutils.modules.reporting.ReportHandler;
+import net.asodev.islandutils.modules.reporting.playersui.ReportingPlayersScreen;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.ObjectSelectionList;
+
+public class ReportOptionsList extends ObjectSelectionList<ReportOptionEntry> {
+
+    private final ReportOptionsScreen screen;
+
+    public ReportOptionsList(ReportOptionsScreen screen) {
+        super(Minecraft.getInstance(), screen.width, screen.height, 64, screen.height - 96, 18);
+        this.screen = screen;
+
+        setRenderHeader(false, 0);
+        setRenderTopAndBottom(false);
+        setRenderBackground(false);
+        for (String reason : ReportHandler.getReasons()) {
+            this.addEntry(new ReportOptionEntry(reason, this, screen));
+        }
+    }
+
+    @Override
+    protected void enableScissor(GuiGraphics graphics) {
+        graphics.enableScissor(this.x0, this.y0 + 2, this.x1, this.y1);
+    }
+
+    @Override
+    protected int getScrollbarPosition() {
+        return this.width / 2 + 90;
+    }
+
+    @Override
+    public int getRowWidth() {
+        return 150;
+    }
+
+    @Override
+    protected void renderBackground(GuiGraphics graphics) {
+        graphics.fillGradient(0, 0, this.width, this.height, 0xc0101010, 0xd0101010);
+        graphics.blitNineSliced(ReportingPlayersScreen.TEXTURE, getRowLeft() - 10, this.y0 - 6, getRowWidth() + 16, this.y1 - this.y0 + 14, 8, 236, 34, 1, 1);
+
+        graphics.drawCenteredString(Minecraft.getInstance().font, "Reporting - " + this.screen.username(), this.width / 2, this.y0 - 6 - 14, 0XFFFFFF);
+    }
+
+    public int width() {
+        return this.width;
+    }
+
+}

--- a/src/main/java/net/asodev/islandutils/modules/reporting/reportui/ReportOptionsScreen.java
+++ b/src/main/java/net/asodev/islandutils/modules/reporting/reportui/ReportOptionsScreen.java
@@ -1,0 +1,73 @@
+package net.asodev.islandutils.modules.reporting.reportui;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.navigation.CommonInputs;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.multiplayer.ClientPacketListener;
+import net.minecraft.network.chat.CommonComponents;
+
+public class ReportOptionsScreen extends Screen {
+
+    private final String username;
+    private ReportOptionsList list;
+
+    public ReportOptionsScreen(String username) {
+        super(CommonComponents.EMPTY);
+        this.username = username;
+    }
+
+    @Override
+    protected void init() {
+        this.list = this.addWidget(new ReportOptionsList(this));
+        this.addRenderableWidget(
+            Button.builder(CommonComponents.GUI_CANCEL, (button) -> this.onClose())
+                .bounds(this.width / 2 - 155, this.height - 38, 150, 20)
+                .build()
+        );
+        this.addRenderableWidget(
+            Button.builder(CommonComponents.GUI_DONE, (button) -> this.complete())
+                .bounds(this.width / 2 - 155 + 160, this.height - 38, 150, 20)
+                .build()
+        );
+    }
+
+    @Override
+    public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
+        if (CommonInputs.selected(keyCode)) {
+            ReportOptionEntry entry = this.list.getSelected();
+            if (entry != null) {
+                this.list.setSelected(entry);
+                this.complete();
+                return true;
+            }
+        }
+
+        return super.keyPressed(keyCode, scanCode, modifiers);
+    }
+
+    @Override
+    public void render(GuiGraphics graphics, int mouseX, int mouseY, float partialTicks) {
+        this.list.render(graphics, mouseX, mouseY, partialTicks);
+        super.render(graphics, mouseX, mouseY, partialTicks);
+    }
+
+    @Override
+    public boolean isPauseScreen() {
+        return false;
+    }
+
+    public void complete() {
+        ReportOptionEntry entry = this.list.getSelected();
+        ClientPacketListener connection = Minecraft.getInstance().getConnection();
+        if (entry != null && connection != null) {
+            connection.sendCommand("report " + this.username + " " + entry.reason());
+            this.onClose();
+        }
+    }
+
+    public String username() {
+        return this.username;
+    }
+}

--- a/src/main/java/net/asodev/islandutils/options/categories/MiscOptions.java
+++ b/src/main/java/net/asodev/islandutils/options/categories/MiscOptions.java
@@ -14,6 +14,7 @@ public class MiscOptions implements OptionsCategory {
 
     boolean pauseConfirm = true;
     boolean showFriendsInGame = true;
+    boolean showReportMenu = true;
     boolean silverPreview = true;
     boolean enableConfigButton = true;
     boolean debugMode = false;
@@ -23,6 +24,9 @@ public class MiscOptions implements OptionsCategory {
     }
     public boolean isShowFriendsInGame() {
         return showFriendsInGame;
+    }
+    public boolean isShowReportMenu() {
+        return showReportMenu;
     }
     public boolean isSilverPreview() {
         return silverPreview;
@@ -48,6 +52,12 @@ public class MiscOptions implements OptionsCategory {
                 .controller(TickBoxControllerBuilder::create)
                 .binding(defaults.showFriendsInGame, () -> showFriendsInGame, value -> this.showFriendsInGame = value)
                 .build();
+        Option<Boolean> showReportMenuOption = Option.<Boolean>createBuilder()
+                .name(Component.translatable("text.autoconfig.islandutils.option.showReportMenu"))
+                .description(OptionDescription.of(Component.translatable("text.autoconfig.islandutils.option.showReportMenu.@Tooltip")))
+                .controller(TickBoxControllerBuilder::create)
+                .binding(defaults.showReportMenu, () -> showReportMenu, value -> this.showReportMenu = value)
+                .build();
         Option<Boolean> silverOption = Option.<Boolean>createBuilder()
                 .name(Component.translatable("text.autoconfig.islandutils.option.silverPreview"))
                 .description(OptionDescription.of(Component.translatable("text.autoconfig.islandutils.option.silverPreview.@Tooltip")))
@@ -71,6 +81,7 @@ public class MiscOptions implements OptionsCategory {
                 .name(Component.literal("Miscellaneous"))
                 .option(pauseOption)
                 .option(showFriendsOption)
+                .option(showReportMenuOption)
                 .option(silverOption)
                 .option(buttonOption)
                 .group(OptionGroup.createBuilder()

--- a/src/main/java/net/asodev/islandutils/util/SuggestionProvider.java
+++ b/src/main/java/net/asodev/islandutils/util/SuggestionProvider.java
@@ -1,0 +1,81 @@
+package net.asodev.islandutils.util;
+
+import com.mojang.brigadier.suggestion.Suggestion;
+import com.mojang.brigadier.suggestion.Suggestions;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientPacketListener;
+import net.minecraft.network.protocol.game.ClientboundCommandSuggestionsPacket;
+import net.minecraft.network.protocol.game.ServerboundCommandSuggestionPacket;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * A class to handle the collection of command suggestions from the server.
+ * <br>
+ * @param <T> The type that the suggestions should be mapped to.
+ */
+public class SuggestionProvider<T> {
+
+    private static final Int2ObjectMap<SuggestionProvider<?>> PROVIDERS = new Int2ObjectOpenHashMap<>();
+
+    private static int nextTransactionId = 7345664; // random number to start with
+
+    private final int transactionId;
+    private final String command;
+    private final Function<Suggestion, T> mapper;
+
+    private final List<Consumer<List<T>>> listeners = new ArrayList<>();
+
+    /**
+     * @param command The command to request suggestions for.
+     * @param mapper The function to map the suggestions to the desired type.
+     */
+    public SuggestionProvider(String command, Function<Suggestion, T> mapper) {
+        this.transactionId = nextTransactionId;
+        this.command = command;
+        this.mapper = mapper;
+        PROVIDERS.put(nextTransactionId, this);
+
+        SuggestionProvider.nextTransactionId++;
+    }
+
+    public void send() {
+        ClientPacketListener connection = Minecraft.getInstance().getConnection();
+        if (connection != null) {
+            connection.send(new ServerboundCommandSuggestionPacket(this.transactionId, this.command));
+        }
+    }
+
+    public SuggestionProvider<T> registerListener(Consumer<List<T>> listener) {
+        listeners.add(listener);
+        return this;
+    }
+
+    public SuggestionProvider<T> unregisterListener(Consumer<List<T>> listener) {
+        listeners.remove(listener);
+        return this;
+    }
+
+    protected void invoke(Suggestions suggestions) {
+        List<T> mappedSuggestions = suggestions.getList().stream().map(mapper).collect(Collectors.toList());
+        listeners.forEach(listener -> listener.accept(mappedSuggestions));
+    }
+
+    public static boolean invoke(ClientboundCommandSuggestionsPacket packet) {
+        SuggestionProvider<?> provider = PROVIDERS.get(packet.getId());
+        if (provider == null) return false;
+        provider.invoke(packet.getSuggestions());
+        return true;
+    }
+
+    public static SuggestionProvider<String> ofString(String command) {
+        return new SuggestionProvider<>(command, Suggestion::getText);
+    }
+
+}

--- a/src/main/resources/assets/island/lang/en_us.json
+++ b/src/main/resources/assets/island/lang/en_us.json
@@ -71,6 +71,8 @@
   "text.autoconfig.islandutils.option.pauseConfirm.@Tooltip": "Adds an extra confirmation screen before you disconnect",
   "text.autoconfig.islandutils.option.showFriendsInGame": "Show which friends are in your game",
   "text.autoconfig.islandutils.option.showFriendsInGame.@Tooltip": "When you join a game, a message will be put in chat with the friends in your game",
+  "text.autoconfig.islandutils.option.showReportMenu": "Show a custom report menu",
+  "text.autoconfig.islandutils.option.showReportMenu.@Tooltip": "When on MCCI, the report menu will be replaced with a custom one and /report <player> will show a menu",
   "text.autoconfig.islandutils.option.silverPreview": "Show silver total",
   "text.autoconfig.islandutils.option.silverPreview.@Tooltip": "Shows the total amount of silver you'll earn in the Scavenging menu",
   "text.autoconfig.islandutils.option.hideSliders": "Hide Sound Sliders if not Online",

--- a/src/main/resources/islandutils.mixins.json
+++ b/src/main/resources/islandutils.mixins.json
@@ -31,6 +31,8 @@
     "notif.ServerSelectionMixin",
     "plobby.PlobbyChestMixin",
     "plobby.PlobbyItemAnalysisMixin",
+    "reporting.ChatScreenMixin",
+    "reporting.MinecraftMixin",
     "resources.MultiplayerJoinMixin",
     "resources.ProgressScreenAccessor",
     "sounds.SoundOptionsMixin",


### PR DESCRIPTION
### What does this PR change?

This PR adds a custom reporting screen to replace the vanilla reporting screen while on MCCI, it will also make it so if a user runs the report command as such `/report user` instead of throwing an error it will bring up a screen with a list of report options.

This PR also adds a new class `SuggestionProvider` this is similar to how the friends in-game system worked except its contained to a single class that can be reused with an easy registration of suggestion suggestion getting systems.

### Showcase

#### Custom Reporting Screen
![image](https://github.com/AsoDesu/IslandUtils/assets/26934102/0911f0ca-1727-4147-9ec2-4f258baa86a3)

#### Reporting Options Screen
![image](https://github.com/AsoDesu/IslandUtils/assets/26934102/de36e81f-bf7a-48db-8b9e-8481c4220490)

### Notes

The report options do allow for translations as to make it better accessible to people playing in other languages as of right now I do not add translation keys for them in english as they are already in english.

Since this does act like the vanilla social interaction screen in the future you can add back the hide messages button(it didnt work as vanilla checks only very specific formats) if #93 is implemented as you can then toggle chat for specific players instead of global.
