### PR TITLE
Added preventing slot highlight

### DIFF
--- a/src/main/java/net/asodev/islandutils/mixins/ui/SlotMixin.java
+++ b/src/main/java/net/asodev/islandutils/mixins/ui/SlotMixin.java
@@ -1,0 +1,35 @@
+package net.asodev.islandutils.mixins.ui;
+
+import net.asodev.islandutils.state.Game;
+import net.asodev.islandutils.state.MccIslandState;
+import net.asodev.islandutils.util.Utils;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(Slot.class)
+public abstract class SlotMixin {
+
+    @Shadow
+    public abstract boolean hasItem();
+
+    @Shadow
+    public abstract ItemStack getItem();
+
+    @Inject(method = "isHighlightable", at = @At("HEAD"), cancellable = true)
+    private void isHighlightable(CallbackInfoReturnable<Boolean> cir) {
+        if (MccIslandState.isOnline() && MccIslandState.getGame().equals(Game.HUB)) {
+            ResourceLocation itemID = Utils.getCustomItemID(this.getItem());
+            if (itemID == null) {
+                cir.setReturnValue(this.hasItem());
+            } else if (itemID.getPath().equals("island_interface.generic.blank")) {
+                cir.setReturnValue(false);
+            }
+        }
+    }
+}

--- a/src/main/resources/islandutils.mixins.json
+++ b/src/main/resources/islandutils.mixins.json
@@ -14,7 +14,8 @@
     "network.GamePacketMixin",
     "network.ServerPacketMixin",
     "resources.PackRepositoryMixin",
-    "sounds.SoundSourceMixin"
+    "sounds.SoundSourceMixin",
+    "ui.SlotMixin"
   ],
   "client": [
     "BossUIMixin",


### PR DESCRIPTION
This pull request makes it so the slot hover highlight doesn't happen when you're hovering over slots that don't contain an item, or contain a blank icon. 

Without feature
![image](https://github.com/AsoDesu/IslandUtils/assets/42754166/fc6346e3-f79e-4897-859d-1e7f13128ce2)


With feature
![image](https://github.com/AsoDesu/IslandUtils/assets/42754166/6aaeb049-bfed-4352-9e0f-3d7e635096cf)
