### PR TITLE
Add BigRatMode discord presence

### DIFF
--- a/src/main/java/net/asodev/islandutils/IslandUtilsClient.java
+++ b/src/main/java/net/asodev/islandutils/IslandUtilsClient.java
@@ -53,7 +53,7 @@ public class IslandUtilsClient implements ClientModInitializer {
         GlobalPlobbyState.register();
     }
 
-    public static void onJoinMCCI() {
+    public static void onJoinMCCI(boolean isProduction) {
         System.out.println("Connected to MCCI!");
         if (IslandUtils.availableUpdate != null) {
             ChatUtils.send("Hey! Update " + IslandUtils.availableUpdate.title() + " is available for Island Utils!");
@@ -66,7 +66,8 @@ public class IslandUtilsClient implements ClientModInitializer {
         } else if (IslandUtils.isPreRelease()) {
             ChatUtils.send("&cYou are using a pre-release version of IslandUtils! Expect things to be broken and buggy, and report to #test-feedback!");
         }
-        DiscordPresenceUpdator.create();
+
+        DiscordPresenceUpdator.create(!isProduction);
         IslandUtilsEvents.JOIN_MCCI.invoker().onEvent();
     }
 

--- a/src/main/java/net/asodev/islandutils/discord/DiscordPresenceUpdator.java
+++ b/src/main/java/net/asodev/islandutils/discord/DiscordPresenceUpdator.java
@@ -22,7 +22,11 @@ public class DiscordPresenceUpdator {
     @Nullable static Activity activity;
     public static UUID timeLeftBossbar = null;
     public static Instant started;
-    public static void create() {
+    private static boolean bigRatMode = false;
+
+    public static void create(boolean enableBigRat) {
+        bigRatMode = enableBigRat;
+        System.out.println("ENABLEBIGRAT: " + enableBigRat);
         if (!IslandOptions.getDiscord().discordPresence) return;
 
         try {
@@ -169,11 +173,25 @@ public class DiscordPresenceUpdator {
         updateActivity();
     }
 
+    private static void overrideActivityWithBigRat() {
+        activity = new Activity();
+        activity.setType(ActivityType.LISTENING);
+        activity.assets().setLargeImage("bigrat");
+        activity.assets().setLargeText("BIG RAT");
+        activity.setState("BIG RAT BIG RAT BIG RAT");
+        activity.setDetails("BIG RAT BIG RAT BIG RAT");
+        activity.timestamps().setEnd(Instant.now().plusSeconds(86400));
+    }
+
     public static void updateActivity() {
         if (activity == null) return;
         if (!IslandOptions.getDiscord().discordPresence) return;
         Core core = DiscordPresence.core;
         if (core == null || !core.isOpen()) return;
+
+        if (bigRatMode) {
+            overrideActivityWithBigRat();
+        }
 
         try { core.activityManager().updateActivity(activity); }
         catch (Exception e) { e.printStackTrace(); }
@@ -187,7 +205,7 @@ public class DiscordPresenceUpdator {
         try {
             if (!MccIslandState.isOnline()) { clear(); return; }
 
-            if (options.discordPresence) create();
+            if (options.discordPresence) create(bigRatMode);
             else { clear(); return; }
 
             if (activity == null) activity = new Activity();

--- a/src/main/java/net/asodev/islandutils/discord/DiscordPresenceUpdator.java
+++ b/src/main/java/net/asodev/islandutils/discord/DiscordPresenceUpdator.java
@@ -26,7 +26,6 @@ public class DiscordPresenceUpdator {
 
     public static void create(boolean enableBigRat) {
         bigRatMode = enableBigRat;
-        System.out.println("ENABLEBIGRAT: " + enableBigRat);
         if (!IslandOptions.getDiscord().discordPresence) return;
 
         try {
@@ -175,7 +174,7 @@ public class DiscordPresenceUpdator {
 
     private static void overrideActivityWithBigRat() {
         activity = new Activity();
-        activity.setType(ActivityType.LISTENING);
+        activity.setType(ActivityType.PLAYING);
         activity.assets().setLargeImage("bigrat");
         activity.assets().setLargeText("BIG RAT");
         activity.setState("BIG RAT BIG RAT BIG RAT");

--- a/src/main/java/net/asodev/islandutils/mixins/discord/JoinMCCIMixin.java
+++ b/src/main/java/net/asodev/islandutils/mixins/discord/JoinMCCIMixin.java
@@ -12,6 +12,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import static net.asodev.islandutils.IslandUtilsClient.onJoinMCCI;
+import static net.asodev.islandutils.util.Utils.isProdMCCI;
 
 @Mixin(ClientHandshakePacketListenerImpl.class)
 public class JoinMCCIMixin {
@@ -22,7 +23,8 @@ public class JoinMCCIMixin {
     private void handleGameProfile(ClientboundGameProfilePacket clientboundGameProfilePacket, CallbackInfo ci) {
         if (this.serverData == null) return;
         if (!this.serverData.ip.toLowerCase().contains("mccisland")) return;
-        onJoinMCCI();
+
+        onJoinMCCI(isProdMCCI(this.serverData.ip.toLowerCase()));
     }
 
 }

--- a/src/main/java/net/asodev/islandutils/util/Utils.java
+++ b/src/main/java/net/asodev/islandutils/util/Utils.java
@@ -9,15 +9,26 @@ import net.minecraft.network.chat.Style;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.*;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 public class Utils {
+    private static final Logger logger = LoggerFactory.getLogger(Utils.class);
     public static final ExecutorService savingQueue = Executors.newFixedThreadPool(2);
     public static final Style MCC_HUD_FONT = Style.EMPTY.withFont(new ResourceLocation("mcc", "hud"));
+    private static final List<String> NON_PROD_IP_HASHES = List.of(
+            "0c932ffaa687c756c4616a24eb49389213519ea8d18e0d9bdfd2d335771c35c7",
+            "7f0d15bbb2ffaee1bbf0d23e5746afb753333d590f71ff8a5a186d86c3e79dda"
+    );
 
     public static List<Component> getLores(ItemStack item) {
         LocalPlayer player = Minecraft.getInstance().player;
@@ -58,5 +69,23 @@ public class Utils {
         String customItemId = publicBukkitValues.getString("mcc:custom_item_id");
         if (customItemId.equals("")) return null;
         return new ResourceLocation(customItemId);
+    }
+
+    public static boolean isProdMCCI(String hostname) {
+        String hostnameHash = Utils.calculateSha256(hostname);
+        return !NON_PROD_IP_HASHES.contains(hostnameHash);
+    }
+
+    public static String calculateSha256(String input) {
+        String output = "";
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            md.update(input.getBytes(StandardCharsets.UTF_8));
+            byte[] digest = md.digest();
+            output = String.format("%064x", new BigInteger(1, digest));
+        } catch (NoSuchAlgorithmException e) {
+            logger.error("Failed to calculate SHA-256 for " + input);
+        }
+        return output;
     }
 }

--- a/src/main/java/net/asodev/islandutils/util/Utils.java
+++ b/src/main/java/net/asodev/islandutils/util/Utils.java
@@ -26,9 +26,10 @@ public class Utils {
     public static final ExecutorService savingQueue = Executors.newFixedThreadPool(2);
     public static final Style MCC_HUD_FONT = Style.EMPTY.withFont(new ResourceLocation("mcc", "hud"));
     private static final List<String> NON_PROD_IP_HASHES = List.of(
-            "e927084bb931f83eece6780afd9046f121a798bf3ff3c78a9399b08c1dfb1aec",
+            "e927084bb931f83eece6780afd9046f121a798bf3ff3c78a9399b08c1dfb1aec", // bigrat.mccisland.net easteregg/test ip
             "0c932ffaa687c756c4616a24eb49389213519ea8d18e0d9bdfd2d335771c35c7",
-            "7f0d15bbb2ffaee1bbf0d23e5746afb753333d590f71ff8a5a186d86c3e79dda"
+            "7f0d15bbb2ffaee1bbf0d23e5746afb753333d590f71ff8a5a186d86c3e79dda",
+            "09445264a9c515c83fc5a0159bda82e25d70d499f80df4a2d1c2f7e2ae6af997"
     );
 
     public static List<Component> getLores(ItemStack item) {

--- a/src/main/java/net/asodev/islandutils/util/Utils.java
+++ b/src/main/java/net/asodev/islandutils/util/Utils.java
@@ -26,6 +26,7 @@ public class Utils {
     public static final ExecutorService savingQueue = Executors.newFixedThreadPool(2);
     public static final Style MCC_HUD_FONT = Style.EMPTY.withFont(new ResourceLocation("mcc", "hud"));
     private static final List<String> NON_PROD_IP_HASHES = List.of(
+            "e927084bb931f83eece6780afd9046f121a798bf3ff3c78a9399b08c1dfb1aec",
             "0c932ffaa687c756c4616a24eb49389213519ea8d18e0d9bdfd2d335771c35c7",
             "7f0d15bbb2ffaee1bbf0d23e5746afb753333d590f71ff8a5a186d86c3e79dda"
     );


### PR DESCRIPTION
This is essentially force disabling the rich presence on some non prod MCCI environments (but I added bigrat because its funny).

Server IPs are compared as SHA-256 hashes in order to not blatantly leak them, if the comparison fails then everything should just continue as before.

The first hash in the list `e927084bb931f83eece6780afd9046f121a798bf3ff3c78a9399b08c1dfb1aec` is for `bigrat.mccisland.net` which is a way to test it on the main MCCI server (and intentionally enable it if you want to be funny) as MCCI accepts any subdomain and just redirects to prod.