### PR TITLE
Fix RSR config button not showing the correct text

### DIFF
--- a/src/main/resources/assets/island/lang/en_us.json
+++ b/src/main/resources/assets/island/lang/en_us.json
@@ -17,7 +17,7 @@
   "text.autoconfig.islandutils.option.bbMusic": "Battle Box Music",
   "text.autoconfig.islandutils.option.sbMusic": "Sky Battle Music",
   "text.autoconfig.islandutils.option.dynaballMusic": "Dynaball Music",
-  "text.autoconfig.islandutils.option.rsrOption": "Rocket Spleef Rush Music",
+  "text.autoconfig.islandutils.option.rsrMusic": "Rocket Spleef Rush Music",
   "text.autoconfig.islandutils.option.pkwMusic": "Parkour Warrior Dojo Music",
   "text.autoconfig.islandutils.option.pkwsMusic": "Parkour Warrior Survivor Music",
   "text.autoconfig.islandutils.option.tgttosDoubleTime": "TGTTOS Double Time Music",


### PR DESCRIPTION
Fixes the button showing this:
![image](https://github.com/AsoDesu/IslandUtils/assets/12937331/73dd95a9-8d17-42c3-b45f-aee316d097ef)
