### PR TITLE
Prevent "Failed to load builder" warnings from spamming the log

### DIFF
--- a/src/main/java/net/asodev/islandutils/mixins/resources/FontManagerMixin.java
+++ b/src/main/java/net/asodev/islandutils/mixins/resources/FontManagerMixin.java
@@ -1,0 +1,30 @@
+package net.asodev.islandutils.mixins.resources;
+
+import com.mojang.blaze3d.font.GlyphProvider;
+import net.minecraft.client.gui.font.FontManager;
+import net.minecraft.client.gui.font.providers.GlyphProviderDefinition;
+import net.minecraft.server.packs.resources.ResourceManager;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+@Mixin(FontManager.class)
+public class FontManagerMixin {
+    @Inject(method = "safeLoad", at = @At("HEAD"), cancellable = true)
+    public void load(FontManager.BuilderId builderId, GlyphProviderDefinition.Loader loader, ResourceManager resourceManager, Executor executor, CallbackInfoReturnable<CompletableFuture<Optional<GlyphProvider>>> cir) {
+        if (builderId.pack().equals("islandutils")) {
+            cir.setReturnValue(CompletableFuture.supplyAsync(() -> {
+                try {
+                    return Optional.of(loader.load(resourceManager));
+                } catch (Exception exception) {
+                    return Optional.empty();
+                }
+            }, executor));
+        }
+    }
+}

--- a/src/main/resources/islandutils.accesswidener
+++ b/src/main/resources/islandutils.accesswidener
@@ -4,3 +4,4 @@ accessWidener v1 named
 #accessible method net/minecraft/server/packs/FilePackResources$SharedZipFileAccess <init> (Ljava/io/File;)V
 #accessible method net/minecraft/util/HttpUtil downloadAndHash (Lcom/google/common/hash/HashFunction;ILnet/minecraft/util/HttpUtil$DownloadProgressListener;Ljava/io/InputStream;Ljava/nio/file/Path;)Lcom/google/common/hash/HashCode;
 #accessible method net/minecraft/client/resources/server/DownloadedPackSource createDownloadNotifier (I)Lnet/minecraft/util/HttpUtil$DownloadProgressListener;
+accessible class net/minecraft/client/gui/font/FontManager$BuilderId

--- a/src/main/resources/islandutils.mixins.json
+++ b/src/main/resources/islandutils.mixins.json
@@ -29,6 +29,7 @@
     "network.PacketListenerMixin",
     "notif.ServerSelectionMixin",
     "plobby.PlobbyChestMixin",
+    "resources.FontManagerMixin",
     "resources.MultiplayerJoinMixin",
     "sounds.SoundOptionsMixin",
     "splits.HologramMixin",


### PR DESCRIPTION
Almost did it before the release, oh well...

All this does is clean the log up a little, the warnings are spammed whenever the resources reload, which happens a lot on Island. Not sure if there's a better way of doing this, it's just the way I previously did it.