### PR TITLE
Insert current minecraft version into fabric version string

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 version = project.mod_version + extraVersion()
 group = project.maven_group
 
-static def extraVersion() {
+def extraVersion() {
     def ENV = System.getenv()
     if (ENV.CI == "true") {
         def branch = ENV.GITHUB_REF
@@ -14,7 +14,7 @@ static def extraVersion() {
         def runNumber = ENV.GITHUB_RUN_NUMBER
         return "-pre+" + runNumber + "-" + branch
     }
-    return ""
+    return "+${project.minecraft_version}"
 }
 
 repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,13 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.20.5
-yarn_mappings=1.20.5+build.1
-loader_version=0.15.10
+minecraft_version=1.20.6
+yarn_mappings=1.20.6+build.3
+loader_version=0.15.11
 # Mod Properties
-mod_version=1.6.8
+mod_version=1.6.9
 maven_group=net.asodev
 archives_base_name=islandutils
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.97.5+1.20.5
+fabric_version=0.100.4+1.20.6


### PR DESCRIPTION
This PR aims to close #134, as the mod version string now adds the current minecraft version, since I assume that this project is switching to this format, judging by the newest tag name.

For this to work on the latest supported mc version (1.20.6), I bumped the version in gradle properties from 1.20.5 to 1.20.6. This generated no compiler warnings, and I also tested the newer version and found no errors, so, everything _should_ work as expected.

I assume that this change requires a minor version bump, so the change will only work **when a new release (1.6.9) is published**, since I bumped the mod_version to 1.6.9. If it needs to be kept at 1.6.8 or changed in any other way, tell me and I'll change it (or change it yourself xd).



