### PR TITLE
Add "sum of best splits" functionality

### DIFF
--- a/src/main/java/net/asodev/islandutils/mixins/network/PacketListenerMixin.java
+++ b/src/main/java/net/asodev/islandutils/mixins/network/PacketListenerMixin.java
@@ -265,7 +265,7 @@ public abstract class PacketListenerMixin extends ClientCommonPacketListenerImpl
             LevelTimer instance = LevelTimer.getInstance();
             if (instance == null) return;
             instance.handleSubtitle(clientboundSetSubtitleTextPacket, ci);
-            renderer.update();
+            if (IslandOptions.getSplits().isShowSumOfBest()) renderer.update();
         }
     }
 

--- a/src/main/java/net/asodev/islandutils/mixins/network/PacketListenerMixin.java
+++ b/src/main/java/net/asodev/islandutils/mixins/network/PacketListenerMixin.java
@@ -3,14 +3,10 @@ package net.asodev.islandutils.mixins.network;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
-import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import net.asodev.islandutils.IslandUtilsClient;
 import net.asodev.islandutils.IslandUtilsEvents;
 import net.asodev.islandutils.discord.DiscordPresenceUpdator;
 import net.asodev.islandutils.modules.FriendsInGame;
-import net.asodev.islandutils.modules.splits.LevelSplits;
-import net.asodev.islandutils.modules.splits.SplitManager;
-import net.asodev.islandutils.modules.splits.sob.SobCalc;
 import net.asodev.islandutils.modules.splits.sob.SobRenderer;
 import net.asodev.islandutils.modules.splits.sob.TeamInfo;
 import net.asodev.islandutils.options.IslandOptions;
@@ -27,7 +23,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.*;
 import net.minecraft.client.resources.sounds.SoundInstance;
 import net.minecraft.commands.CommandSourceStack;
-import net.minecraft.core.RegistryAccess;
 import net.minecraft.network.Connection;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.Style;
@@ -37,7 +32,6 @@ import net.minecraft.network.protocol.game.*;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.entity.player.ProfileKeyPair;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.scores.*;
 import org.spongepowered.asm.mixin.Final;
@@ -62,20 +56,15 @@ public abstract class PacketListenerMixin extends ClientCommonPacketListenerImpl
 
     @Shadow private CommandDispatcher<CommandSourceStack> commands;
 
-    @Shadow public abstract RegistryAccess.Frozen registryAccess();
-
-    @Shadow public abstract void setKeyPair(ProfileKeyPair profileKeyPair);
-
     @Final
     @Shadow private Scoreboard scoreboard;
-
-    @Shadow public abstract boolean isAcceptingMessages();
 
     protected PacketListenerMixin(Minecraft minecraft, Connection connection, CommonListenerCookie commonListenerCookie) {
         super(minecraft, connection, commonListenerCookie);
     }
 
     // Patterns for the Map & Modifier options on scoreboard
+    @Unique
     final Map<String, Pattern> scoreboardPatterns = Map.of(
             "MAP", Pattern.compile("MAP: (?<map>\\w+(?:,? \\w+)*)"),
             "MODIFIER", Pattern.compile("MODIFIER: (?<modifier>\\w+(?:,? \\w+)*)"),

--- a/src/main/java/net/asodev/islandutils/modules/splits/LevelSplits.java
+++ b/src/main/java/net/asodev/islandutils/modules/splits/LevelSplits.java
@@ -55,6 +55,20 @@ public class LevelSplits {
         return value / 1000d;
     }
 
+    public Optional<Split> getRawSplit(String level) {
+        return Optional.ofNullable(splits.get(level));
+    }
+
+    public Optional<Split> getSplitNoColor(String level) {
+        List<String> allPossibleLevels = List.of(
+                String.format("green%s", level),
+                String.format("yellow%s", level),
+                String.format("red%s", level)
+        );
+        Optional<String> match = allPossibleLevels.stream().filter(s -> splits.containsKey(s)).findFirst();
+        return match.map(s -> splits.get(s));
+    }
+
     public JsonObject toJson() {
         JsonObject object = new JsonObject();
         object.addProperty("name", name);

--- a/src/main/java/net/asodev/islandutils/modules/splits/sob/AdvancedInfo.java
+++ b/src/main/java/net/asodev/islandutils/modules/splits/sob/AdvancedInfo.java
@@ -1,0 +1,4 @@
+package net.asodev.islandutils.modules.splits.sob;
+
+public record AdvancedInfo(Long time, String path) {
+}

--- a/src/main/java/net/asodev/islandutils/modules/splits/sob/SobCalc.java
+++ b/src/main/java/net/asodev/islandutils/modules/splits/sob/SobCalc.java
@@ -1,0 +1,227 @@
+package net.asodev.islandutils.modules.splits.sob;
+
+import net.asodev.islandutils.modules.splits.LevelSplits;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.stream.IntStream;
+
+public class SobCalc {
+    private static final List<String> mainStages = List.of(
+            "M1-1", "M1-2", "M1-3",
+            "M2-1", "M2-2", "M2-3",
+            "M3-1", "M3-2", "M3-3"
+    );
+    private static final List<String> bonusStages = List.of(
+            "B1-1", "B1-2", "B1-3",
+            "B2-1", "B2-2", "B2-3",
+            "B3-1", "B3-2", "B3-3"
+    );
+    private static final List<String> finalStages = List.of(
+            "greenB4-1", "yellowB4-1", "redB4-1"
+    );
+    private static final List<String> expertFinale = List.of(
+            "redB4-1", "redT3-4"
+    );
+    private static final List<String> mainTransitions = List.of(
+            "T0-1", "T1-2", "T2-3"
+    );
+    private static final List<String> bonusTransitions = List.of(
+            "TB0-1", "TB1-2", "TB2-3"
+    );
+
+    public static Optional<Long> timesFromSplitsNoColor(LevelSplits splitInfo, List<String> splits) {
+        List<Optional<Long>> splitList = splits
+                .stream()
+                .map(splitInfo::getSplitNoColor)
+                .map(os -> os.map(LevelSplits.Split::best))
+                .toList();
+        if (splitList.stream().anyMatch(Optional::isEmpty)) return Optional.empty();
+        return splitList
+                .stream()
+                .flatMap(Optional::stream)
+                .reduce(Long::sum);
+    }
+
+
+    public static Optional<Long> timesFromSplitsRaw(LevelSplits splitInfo, List<String> splits) {
+        List<Optional<Long>> splitList = splits
+                .stream()
+                .map(splitInfo::getRawSplit)
+                .map(os -> os.map(LevelSplits.Split::best))
+                .toList();
+        if (splitList.stream().anyMatch(Optional::isEmpty)) return Optional.empty();
+        return splitList
+                .stream()
+                .flatMap(Optional::stream)
+                .reduce(Long::sum);
+    }
+
+    public static Optional<Long> bestFinal(LevelSplits splits) {
+        long minTime = Long.MAX_VALUE;
+        String minName = null;
+        for (String splitName : finalStages) {
+            Optional<LevelSplits.Split> splitTime = splits.getRawSplit(splitName);
+            if (splitTime.isEmpty()) continue;
+            long bestTime = splitTime.get().best();
+            if (bestTime < minTime) {
+                minTime = bestTime;
+                minName = splitName;
+            }
+        }
+        if (minName == null) return Optional.empty();
+        String minColor = minName.split("B")[0];
+        String transitionSplitName = String.format("%sT3-4", minColor);
+        Optional<LevelSplits.Split> finaleTransitionTime = splits.getRawSplit(transitionSplitName);
+        if (finaleTransitionTime.isEmpty()) return Optional.empty();
+        return Optional.of(minTime
+                + finaleTransitionTime.get().best()
+                - 1500 // Compensate for 1500 ms delay
+        );
+    }
+
+    public static Optional<Long> standardTime(LevelSplits splits) {
+        Optional<Long> mainTime = timesFromSplitsNoColor(splits, mainStages);
+        Optional<Long> mainTransitionsTime = timesFromSplitsRaw(splits, mainTransitions)
+                .map(s -> s - 4500); // Compensate for three transition delays
+        Optional<Long> finaleTime = bestFinal(splits);
+        return mainTime
+                .flatMap(m -> mainTransitionsTime
+                        .flatMap(mt -> finaleTime
+                                .map(ft -> m + mt + ft)));
+    }
+
+    public static Optional<List<Long>> getTimesFromStage(int howManyComplete, String stageName, LevelSplits splits) {
+        List<Optional<Long>> times = IntStream
+                .range(0, howManyComplete)
+                .mapToObj(i -> String.format("%s-%d", stageName, i + 1))
+                .map(splits::getSplitNoColor)
+                .map(s -> s.map(LevelSplits.Split::best))
+                .toList();
+        if (times.stream().anyMatch(Optional::isEmpty)) return Optional.empty();
+        return Optional.of(times.stream().flatMap(Optional::stream).toList());
+    }
+
+    public static Optional<Long> additionalBonusTime(int howManyComplete, String stageName, LevelSplits splits, long returnTime) {
+        int stage = Integer.parseInt(String.valueOf(stageName.charAt(1)));
+        if (howManyComplete == 0) {
+            String transitionString = String.format("T%d-%d", stage - 1, stage);
+            return splits
+                    .getRawSplit(transitionString)
+                    .map(LevelSplits.Split::best)
+                    .map(s -> s - 1500); // Compensate for 1500 ms delay
+        }
+        long toAdd = returnTime;
+
+        String splitName = String.format("TB%d-%d", stage - 1, stage);
+        Optional<Long> tb = splits.getRawSplit(splitName).map(LevelSplits.Split::best);
+        if (tb.isEmpty()) return Optional.empty();
+        toAdd += tb.get();
+
+        if (howManyComplete != 3) {
+            Optional<Long> uncompletedStageSplit = splits.getRawSplit("U").map(LevelSplits.Split::best);
+            if (uncompletedStageSplit.isEmpty()) return Optional.empty();
+            toAdd += uncompletedStageSplit.get();
+        }
+        toAdd -= 1500; // Compensate for 1500 ms delay
+        return Optional.of(toAdd);
+    }
+
+    public static String buildBonusPathString(int howManyComplete, String stage) {
+        if (howManyComplete == 0) return "";
+        StringBuilder str = new StringBuilder(" ->");
+        for (int i = 1; i <= howManyComplete; i++) {
+            str.append(String.format(" %s-%d -> ", stage, i));
+        }
+        str.append("R");
+        return str.toString();
+    }
+
+    public static Optional<AdvancedInfo> advancedTime(LevelSplits splits) {
+        Optional<Long> mainTime = timesFromSplitsNoColor(splits, mainStages);
+        if (mainTime.isEmpty()) return Optional.empty();
+        Optional<Long> returnTime = splits.getRawSplit("R").map(LevelSplits.Split::best);
+        if (returnTime.isEmpty()) return Optional.empty();
+        Map<Long, String> variants = new HashMap<>();
+        for (int b1 = 0; b1 < 4; b1++) {
+            for (int b2 = 0; b2 < 4; b2++) {
+                for (int b3 = 0; b3 < 4; b3++) {
+                    for (String finalS : finalStages) {
+                        long medalsForFinish;
+                        if (finalS.contains("green")) {
+                            medalsForFinish = 1;
+                        } else if (finalS.contains("yellow")) {
+                            medalsForFinish = 2;
+                        } else {
+                            medalsForFinish = 3;
+                        }
+                        if (9 + b1 + b2 + b3 + medalsForFinish <= 16) continue;
+                        Optional<LevelSplits.Split> finalStageSplit = splits.getRawSplit(finalS);
+                        if (finalStageSplit.isEmpty()) continue;
+                        long finaleTime = finalStageSplit.get().best();
+
+                        Optional<List<Long>> b1_times = getTimesFromStage(b1, "B1", splits);
+                        Optional<List<Long>> b2_times = getTimesFromStage(b2, "B2", splits);
+                        Optional<List<Long>> b3_times = getTimesFromStage(b3, "B3", splits);
+                        if (b1_times.isEmpty() || b2_times.isEmpty() || b3_times.isEmpty()) continue;
+                        ArrayList<Long> combined = new ArrayList<>();
+
+                        Optional<Long> b1_add = additionalBonusTime(b1, "B1", splits, returnTime.get());
+                        Optional<Long> b2_add = additionalBonusTime(b2, "B2", splits, returnTime.get());
+                        Optional<Long> b3_add = additionalBonusTime(b3, "B3", splits, returnTime.get());
+                        if (b1_add.isEmpty() || b2_add.isEmpty() || b3_add.isEmpty()) continue;
+
+                        combined.add(mainTime.get());
+                        combined.addAll(b1_times.get());
+                        combined.addAll(b2_times.get());
+                        combined.addAll(b3_times.get());
+                        combined.add(b1_add.get());
+                        combined.add(b2_add.get());
+                        combined.add(b3_add.get());
+                        combined.add(finaleTime);
+
+                        String path = String.format(
+                                "START%s -> M1%s -> M2%s -> M3 -> %s",
+                                buildBonusPathString(b1, "B1"),
+                                buildBonusPathString(b2, "B2"),
+                                buildBonusPathString(b3, "B3"),
+                                finalS
+                        );
+                        long sum = combined.stream().reduce(Long::sum).get();
+                        variants.put(sum, path);
+                    }
+                }
+            }
+        }
+        return variants.keySet().stream().min(Long::compareTo).map(t -> new AdvancedInfo(t, variants.get(t)));
+    }
+
+    public static Optional<Long> expertTime(LevelSplits splits) {
+        Optional<Long> mainTime = timesFromSplitsNoColor(splits, mainStages);
+        Optional<Long> bonusTime = timesFromSplitsNoColor(splits, bonusStages);
+        Optional<Long> bonusTransitionsTime = timesFromSplitsRaw(splits, bonusTransitions)
+                .map(s -> s - 4500); // Compensate for three transition delays
+        Optional<Long> returnsTime = splits.getRawSplit("R").map(LevelSplits.Split::best);
+        Optional<Long> finaleTime = timesFromSplitsRaw(splits, expertFinale);
+        if (mainTime.isEmpty() ||
+                bonusTime.isEmpty() ||
+                bonusTransitionsTime.isEmpty() ||
+                finaleTime.isEmpty() ||
+                returnsTime.isEmpty())
+            return Optional.empty();
+
+        return Optional.of(mainTime.get() +
+                bonusTime.get() +
+                bonusTransitionsTime.get() +
+                (returnsTime.get() * 3 - 4500) // Compensate for three transition delays
+                + finaleTime.get());
+    }
+
+    public static String format(long sum) {
+        Duration duration = Duration.ofMillis(sum);
+        long MM = duration.toMinutes();
+        long SS = duration.toSecondsPart();
+        long MS = duration.toMillisPart();
+        return String.format(" (%02d:%02d.%03d)", MM, SS, MS);
+    }
+}

--- a/src/main/java/net/asodev/islandutils/modules/splits/sob/SobRenderer.java
+++ b/src/main/java/net/asodev/islandutils/modules/splits/sob/SobRenderer.java
@@ -1,0 +1,43 @@
+package net.asodev.islandutils.modules.splits.sob;
+
+import net.asodev.islandutils.modules.splits.LevelSplits;
+import net.asodev.islandutils.modules.splits.SplitManager;
+import net.asodev.islandutils.state.MccIslandState;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.world.scores.PlayerTeam;
+
+public class SobRenderer {
+    private static final int SOB_COLOR = 0x32cd32;
+
+    private final TeamInfo teamInfo;
+
+    public SobRenderer(TeamInfo teamInfo) {
+        this.teamInfo = teamInfo;
+    }
+
+    public void update() {
+        LevelSplits splits = SplitManager.getCourseSplits(MccIslandState.getMap());
+        SobCalc.standardTime(splits).ifPresent(t -> updateTeamWithTime(teamInfo.standard(), t));
+        SobCalc.advancedTime(splits).ifPresent(t -> updateTeamWithTime(teamInfo.advanced(), t.time()));
+        SobCalc.expertTime(splits).ifPresent(t -> updateTeamWithTime(teamInfo.expert(), t));
+    }
+
+    private Component getOriginalComp(PlayerTeam from) {
+        Component ogPrefix = from.getPlayerPrefix();
+        MutableComponent newPrefix = Component.empty();
+        for (Component c : ogPrefix.getSiblings()) {
+            if (c.getString().contains("(")) continue;
+            newPrefix.append(c);
+        }
+        return newPrefix;
+    }
+
+    private void updateTeamWithTime(PlayerTeam team, long time) {
+        MutableComponent timeComp = Component
+                .literal(SobCalc.format(time))
+                .withColor(SOB_COLOR);
+        team.setPlayerPrefix(Component.empty().append(getOriginalComp(team)).append(timeComp));
+    }
+
+}

--- a/src/main/java/net/asodev/islandutils/modules/splits/sob/TeamInfo.java
+++ b/src/main/java/net/asodev/islandutils/modules/splits/sob/TeamInfo.java
@@ -1,0 +1,42 @@
+package net.asodev.islandutils.modules.splits.sob;
+
+import net.minecraft.world.scores.*;
+
+import java.util.Optional;
+
+public record TeamInfo(PlayerTeam standard, PlayerTeam advanced, PlayerTeam expert) {
+    private static final int STANDARD = 10, ADVANCED = 8, EXPERT = 6;
+
+    public static Optional<TeamInfo> fromScoreboard(Scoreboard scoreboard) {
+        String STDName, ADVName, EXPName;
+        STDName = ADVName = EXPName = null;
+        for (ScoreHolder scoreHolder : scoreboard.getTrackedPlayers()) {
+            String name = scoreHolder.getScoreboardName();
+            for (Objective objective : scoreboard.getObjectives()) {
+                ReadOnlyScoreInfo info = scoreboard.getPlayerScoreInfo(scoreHolder, objective);
+                if (info == null) continue;
+                switch (info.value()) {
+                    case STANDARD -> STDName = name;
+                    case ADVANCED -> ADVName = name;
+                    case EXPERT -> EXPName = name;
+                }
+            }
+        }
+        if (STDName == null || ADVName == null || EXPName == null) return Optional.empty();
+        PlayerTeam STDTeam, ADVTeam, EXPTeam;
+        STDTeam = ADVTeam = EXPTeam = null;
+        for (PlayerTeam team : scoreboard.getPlayerTeams()) {
+            for (String playerName : team.getPlayers()) {
+                if (playerName.equals(STDName)) {
+                    STDTeam = team;
+                } else if (playerName.equals(ADVName)) {
+                    ADVTeam = team;
+                } else if (playerName.equals(EXPName)) {
+                    EXPTeam = team;
+                }
+            }
+        }
+        if (STDTeam == null || ADVTeam == null || EXPTeam == null) return Optional.empty();
+        return Optional.of(new TeamInfo(STDTeam, ADVTeam, EXPTeam));
+    }
+}

--- a/src/main/java/net/asodev/islandutils/modules/splits/ui/DojoSplitUI.java
+++ b/src/main/java/net/asodev/islandutils/modules/splits/ui/DojoSplitUI.java
@@ -5,16 +5,9 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.components.LerpingBossEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.Style;
 import net.minecraft.resources.ResourceLocation;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Stream;
 
 public class DojoSplitUI implements SplitUI {
     private static final ResourceLocation BAR_TEXTURE = new ResourceLocation("island", "textures/gui/pkw_splits.png");

--- a/src/main/java/net/asodev/islandutils/options/categories/SplitsCategory.java
+++ b/src/main/java/net/asodev/islandutils/options/categories/SplitsCategory.java
@@ -24,6 +24,7 @@ public class SplitsCategory implements OptionsCategory {
     boolean sendSplitTime = true;
     boolean showTimer = true;
     boolean showSplitImprovements = true;
+    boolean showSumOfBest = true;
     int showTimerImprovementAt = -3;
     SplitType saveMode = SplitType.BEST;
 
@@ -52,6 +53,12 @@ public class SplitsCategory implements OptionsCategory {
                 .controller(TickBoxControllerBuilder::create)
                 .binding(defaults.showSplitImprovements, () -> showSplitImprovements, value -> this.showSplitImprovements = value)
                 .build();
+        Option<Boolean> showSumOfBestOption = Option.<Boolean>createBuilder()
+                .name(Component.translatable("text.autoconfig.islandutils.option.showSumOfBest"))
+                .description(OptionDescription.of(Component.translatable("text.autoconfig.islandutils.option.showSumOfBest.@Tooltip")))
+                .controller(TickBoxControllerBuilder::create)
+                .binding(defaults.showSumOfBest, () -> showSumOfBest, value -> this.showSumOfBest = value)
+                .build();
         Option<Integer> showImprovesAtOption = Option.<Integer>createBuilder()
                 .name(Component.translatable("text.autoconfig.islandutils.option.showTimerImprovementAt"))
                 .description(OptionDescription.of(Component.translatable("text.autoconfig.islandutils.option.showTimerImprovementAt.@Tooltip")))
@@ -77,6 +84,7 @@ public class SplitsCategory implements OptionsCategory {
                 .option(showOption)
                 .option(showImprovesOption)
                 .option(showImprovesAtOption)
+                .option(showSumOfBestOption)
                 .option(saveOption)
                 .option(clearSplits)
                 .build();
@@ -103,6 +111,10 @@ public class SplitsCategory implements OptionsCategory {
     public boolean isShowSplitImprovements() {
         return enablePkwSplits && showSplitImprovements;
     }
+    public boolean isShowSumOfBest() {
+        return showSumOfBest;
+    }
+
     public int getShowTimerImprovementAt() {
         return showTimerImprovementAt;
     }

--- a/src/main/resources/assets/island/lang/en_us.json
+++ b/src/main/resources/assets/island/lang/en_us.json
@@ -64,6 +64,8 @@
   "text.autoconfig.islandutils.option.clearSplits.@Tooltip": "This will clear all of your saved segments. These can not be recovered.",
   "text.autoconfig.islandutils.option.saveMode": "Split save mode",
   "text.autoconfig.islandutils.option.saveMode.@Tooltip": "How to save splits\n\n§lBest Time§r: Uses your best time on each segment\n\n§lAverage Time§r: Uses your average time on a segment",
+  "text.autoconfig.islandutils.option.showSumOfBest": "Show sum of best splits",
+  "text.autoconfig.islandutils.option.showSumOfBest.@Tooltip": "Shows the sum your of best splits. To see the path for the best advanced route, use '/showadvancedpath'",
   "islandutils.splittype.best": "Best Time",
   "islandutils.splittype.avg": "Average Time",
 


### PR DESCRIPTION
Apps like LiveSplit have this functionality, where you sum all of your best splits and combine them into the "theoretically" best possible time. I added something similar here.

I had to rewrite the timer code quite a bit for this to work, since the old timer did not account for start -> M/B1-1, M3-3 -> finale and B1/2/3-3 -> main route transition times. I tried to make changes as little as possible, and, personally, did not see any breakage.

I also register the /showadvancedpath command through the recommended fabric way of hooking into ClientCommandRegistrationCallback, and not through packets, just cus I find it easier. 

Here's the screenshot of how it looks:
![Screenshot_20240710_234144](https://github.com/AsoDesu/IslandUtils/assets/61428316/c1295a91-bb4b-4222-86c3-4db88d664992)
