### PR TITLE
fix: loud crafting notification sound

### DIFF
--- a/src/main/java/net/asodev/islandutils/modules/crafting/state/CraftingNotifier.java
+++ b/src/main/java/net/asodev/islandutils/modules/crafting/state/CraftingNotifier.java
@@ -42,13 +42,13 @@ public class CraftingNotifier implements ClientTickEvents.EndTick {
             if (!MccIslandState.isOnline() || client.getOverlay() instanceof LoadingOverlay) continue;
             if (item.hasSentNotif()) continue;
 
-            sendNotif(client, item);
+            sendNotif(client, item, !anythingHasChanged);
             anythingHasChanged = true;
         }
         if (anythingHasChanged) CraftingItems.save();
     }
 
-    public void sendNotif(Minecraft client, CraftingItem item) {
+    public void sendNotif(Minecraft client, CraftingItem item, boolean canMakeSound) {
         CraftingOptions options = IslandOptions.getCrafting();
         item.setHasSentNotif(true);
 
@@ -63,7 +63,7 @@ public class CraftingNotifier implements ClientTickEvents.EndTick {
             shouldMakeSound = true;
         }
 
-        if (shouldMakeSound) {
+        if (shouldMakeSound && canMakeSound) {
             sendNotifSound();
         }
     }


### PR DESCRIPTION
When multiple crafts complete at once (such as when you join the server after a while), the notification sound plays multiple times at once and it can be very loud. This ensures that the sound only plays once per tick.