### PR TITLE
Fix switching lobbies on the same instance re-sending the friends message

### DIFF
--- a/src/main/java/net/asodev/islandutils/IslandUtilsEvents.java
+++ b/src/main/java/net/asodev/islandutils/IslandUtilsEvents.java
@@ -4,12 +4,21 @@ import com.noxcrew.noxesium.network.clientbound.ClientboundMccGameStatePacket;
 import net.asodev.islandutils.state.Game;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
+import net.minecraft.network.Connection;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientboundSystemChatPacket;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.function.Consumer;
 
 public class IslandUtilsEvents {
+
+    public static Event<PacketReceived> PACKET_RECEIVED = EventFactory.createArrayBacked(PacketReceived.class, callbacks -> (packet, callbackInfo) -> {
+        for (PacketReceived callback : callbacks) {
+            callback.onPacketReceived(packet, callbackInfo);
+        }
+    });
 
     public static Event<GameChangeCallback> GAME_CHANGE = EventFactory.createArrayBacked(GameChangeCallback.class, callbacks -> game -> {
         for (GameChangeCallback callback : callbacks) {
@@ -47,6 +56,11 @@ public class IslandUtilsEvents {
     });
 
     @FunctionalInterface
+    public interface PacketReceived {
+        void onPacketReceived(Packet<?> packet, CallbackInfo callbackInfo);
+    }
+
+    @FunctionalInterface
     public interface GameChangeCallback {
         void onGameChange(Game to);
     }
@@ -78,6 +92,7 @@ public class IslandUtilsEvents {
         public void cancel() {
             shouldCancel = true;
         }
+
         public void replace(T replacement) {
             this.replacement = replacement;
         }
@@ -85,6 +100,7 @@ public class IslandUtilsEvents {
         public void withCancel(Consumer<Boolean> consumer) {
             if (shouldCancel) consumer.accept(shouldCancel);
         }
+
         public void withReplacement(Consumer<T> consumer) {
             if (replacement != null) consumer.accept(replacement);
         }

--- a/src/main/java/net/asodev/islandutils/mixins/network/ConnectionMixin.java
+++ b/src/main/java/net/asodev/islandutils/mixins/network/ConnectionMixin.java
@@ -1,0 +1,20 @@
+package net.asodev.islandutils.mixins.network;
+
+import io.netty.channel.ChannelHandlerContext;
+import net.asodev.islandutils.IslandUtilsEvents;
+import net.minecraft.network.Connection;
+import net.minecraft.network.protocol.Packet;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Connection.class)
+public class ConnectionMixin {
+
+    @Inject(at = @At("HEAD"), method = "channelRead0(Lio/netty/channel/ChannelHandlerContext;Lnet/minecraft/network/protocol/Packet;)V", cancellable = true)
+    public void channelRead(ChannelHandlerContext channelHandlerContext, Packet<?> packet, CallbackInfo ci) {
+        IslandUtilsEvents.PACKET_RECEIVED.invoker().onPacketReceived(packet, ci);
+    }
+
+}

--- a/src/main/java/net/asodev/islandutils/modules/FriendsInGame.java
+++ b/src/main/java/net/asodev/islandutils/modules/FriendsInGame.java
@@ -2,7 +2,6 @@ package net.asodev.islandutils.modules;
 
 import net.asodev.islandutils.IslandUtilsEvents;
 import net.asodev.islandutils.options.IslandOptions;
-import net.asodev.islandutils.options.categories.MiscOptions;
 import net.asodev.islandutils.state.Game;
 import net.asodev.islandutils.state.MccIslandState;
 import net.asodev.islandutils.util.ChatUtils;
@@ -13,31 +12,81 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientPacketListener;
 import net.minecraft.client.multiplayer.PlayerInfo;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.game.ClientboundCommandSuggestionsPacket;
+import net.minecraft.network.protocol.game.ClientboundTabListPacket;
 import net.minecraft.network.protocol.game.ServerboundCommandSuggestionPacket;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public class FriendsInGame {
-    public static final int TRANSACTION_ID = 6775161;
+
+    private static final int TRANSACTION_ID = 6775161;
+    private static final ServerboundCommandSuggestionPacket SERVERBOUND_COMMAND_SUGGESTION_PACKET = new ServerboundCommandSuggestionPacket(TRANSACTION_ID, "/friend remove ");
+    private static final Pattern INSTANCE_PATTERN = Pattern.compile("(?i)(INSTANCE|FISHTANCE) (\\d+)", Pattern.UNICODE_CHARACTER_CLASS);
+    private static final long DEBOUNCE_TIME_MS = 10;
+    private static final int MESSAGE_SEND_DELAY_TICKS = 35;
+
     private static List<String> friends = new ArrayList<>();
+    private static @Nullable Integer currentInstance = null;
+    private static @Nullable Integer lastInstance = null;
+    private static long lastFriendMessageTimestamp = 0;
 
     public static void init() {
+
         IslandUtilsEvents.GAME_UPDATE.register((game) -> {
             friends.clear();
-            ServerboundCommandSuggestionPacket packet = new ServerboundCommandSuggestionPacket(TRANSACTION_ID, "/friend remove ");
             ClientPacketListener connection = Minecraft.getInstance().getConnection();
-            if (connection != null) connection.send(packet);
+            if (connection != null) connection.send(SERVERBOUND_COMMAND_SUGGESTION_PACKET);
+        });
+
+        IslandUtilsEvents.PACKET_RECEIVED.register((packet, callbackInfo) -> {
+
+            // For finding what instance (or fishtance…) the player is on
+            if (packet instanceof ClientboundTabListPacket tablistPacket) {
+                var rawString = tablistPacket.footer().getString();
+                var matcher = INSTANCE_PATTERN.matcher(rawString);
+
+                if (matcher.find()) {
+                    var newInstance = Integer.parseInt(matcher.group(2));
+                    lastInstance = currentInstance;
+                    currentInstance = newInstance;
+                } else {
+                    lastInstance = null;
+                    currentInstance = null;
+                }
+            }
+
+            // Get friend names
+            // Moved from PacketListenerMixin
+            else if (packet instanceof ClientboundCommandSuggestionsPacket suggestionsPacket) {
+                if (suggestionsPacket.id() != TRANSACTION_ID) return;
+
+                callbackInfo.cancel();
+                List<String> friends = suggestionsPacket
+                        .suggestions()
+                        .stream().map(ClientboundCommandSuggestionsPacket.Entry::text)
+                        .collect(Collectors.toList());
+                FriendsInGame.setFriends(friends);
+            }
         });
     }
 
     public static void setFriends(List<String> friends) {
         FriendsInGame.friends = friends;
-        Scheduler.schedule(35, FriendsInGame::sendFriendsInGame);
+        Scheduler.schedule(MESSAGE_SEND_DELAY_TICKS, FriendsInGame::sendFriendsInGame);
     }
 
     public static void sendFriendsInGame(Minecraft client) {
         if (!shouldSendFriends()) return;
+
+        var currentTime = System.currentTimeMillis();
+        if (currentTime - lastFriendMessageTimestamp < DEBOUNCE_TIME_MS) return;
+        lastFriendMessageTimestamp = currentTime;
+
         StringBuilder friendsInThisGame = new StringBuilder();
         boolean hasFriends = false;
 
@@ -50,6 +99,7 @@ public class FriendsInGame {
                 friendsInThisGame.append(", ").append(name);
             }
         }
+
         if (!hasFriends) return;
         String friendString = friendsInThisGame.toString().replaceFirst(", ", "");
 
@@ -64,8 +114,21 @@ public class FriendsInGame {
     }
 
     public static boolean shouldSendFriends() {
-        MiscOptions misc = IslandOptions.getMisc();
-        return MccIslandState.getGame() == Game.HUB ? misc.isShowFriendsInLobby() : misc.isShowFriendsInGame();
+        var game = MccIslandState.getGame();
+        var misc = IslandOptions.getMisc();
+
+        if (isInSameInstance(game)) {
+            return false;
+        }
+
+        return game == Game.HUB
+                ? misc.isShowFriendsInLobby()
+                : misc.isShowFriendsInGame();
     }
 
+    private static boolean isInSameInstance(Game game) {
+        return (game == Game.HUB || game == Game.FISHING)
+                && currentInstance != null
+                && currentInstance.equals(lastInstance);
+    }
 }

--- a/src/main/java/net/asodev/islandutils/state/MccIslandState.java
+++ b/src/main/java/net/asodev/islandutils/state/MccIslandState.java
@@ -25,6 +25,7 @@ public class MccIslandState {
     public static Game getGame() {
         return game;
     }
+
     public static void setGame(Game game) {
         if (MccIslandState.game != game) {
             ChatUtils.debug("MccIslandState - Changed game to: " + game);

--- a/src/main/resources/islandutils.mixins.json
+++ b/src/main/resources/islandutils.mixins.json
@@ -12,6 +12,7 @@
     "cosmetics.PreviewTutorialMixin",
     "discord.ConnectionMixin",
     "discord.ScoreDisplayMixin",
+    "network.ConnectionMixin",
     "resources.PackRepositoryMixin",
     "ui.SlotMixin"
   ],


### PR DESCRIPTION
Also:
- moved the packet handling to the `FriendsInGame` class instead of `PacketListenerMixin`
- cleaned up code
- fixed the message being sent twice

fixes #183 #194 