### PR TITLE
Weapon Skin preview + new Island Update fixes

### DIFF
--- a/src/main/java/net/asodev/islandutils/mixins/cosmetics/ChestScreenMixin.java
+++ b/src/main/java/net/asodev/islandutils/mixins/cosmetics/ChestScreenMixin.java
@@ -61,8 +61,7 @@ public abstract class ChestScreenMixin extends Screen {
 
     @Inject(method = "renderSlot", at = @At("TAIL"))
     private void renderSlot(GuiGraphics guiGraphics, Slot slot, CallbackInfo ci) {
-        if (!MccIslandState.isOnline()) return;
-        if (MccIslandState.getGame() != Game.HUB && MccIslandState.getGame() != Game.FISHING) return;
+        if (!CosmeticState.shouldShowCosmeticPreview()) return;
         if (!slot.hasItem()) return;
 
         boolean shouldRender = false;
@@ -114,8 +113,7 @@ public abstract class ChestScreenMixin extends Screen {
 
     @Inject(method = "mouseDragged", at = @At("HEAD"))
     private void mouseDragged(double mouseX, double mouseY, int button, double deltaX, double deltaY, CallbackInfoReturnable<Boolean> cir) {
-        if (!MccIslandState.isOnline()) return;
-        if (MccIslandState.getGame() != Game.HUB && MccIslandState.getGame() != Game.FISHING) return;
+        if (!CosmeticState.shouldShowCosmeticPreview()) return;
 
         CosmeticState.yRot = CosmeticState.yRot - Double.valueOf(deltaX).floatValue();
         CosmeticState.xRot = CosmeticState.xRot - Double.valueOf(deltaY).floatValue();
@@ -133,7 +131,8 @@ public abstract class ChestScreenMixin extends Screen {
     @Inject(method = "slotClicked", at = @At("HEAD"))
     private void slotClicked(Slot slot, int i, int j, ClickType clickType, CallbackInfo ci) {
         if (!MccIslandState.isOnline()) return;
-        if (MccIslandState.getGame() != Game.HUB && MccIslandState.getGame() != Game.FISHING) return;
+        if (!MccIslandState.getGame().isHubGame()) return;
+
         if (slot == null || !slot.hasItem()) return;
         ItemStack stack = slot.getItem();
         if (CosmeticState.canBeEquipped(stack)) {
@@ -148,10 +147,8 @@ public abstract class ChestScreenMixin extends Screen {
 
     @Unique
     private void triggerPreviewClicked(int keyCode) {
-        if (!MccIslandState.isOnline()) return;
-        if (!IslandOptions.getCosmetics().isShowPlayerPreview()) return;
+        if (!CosmeticState.shouldShowCosmeticPreview()) return;
         if (hoveredSlot == null || !hoveredSlot.hasItem()) return;
-        if (MccIslandState.getGame() != Game.HUB && MccIslandState.getGame() != Game.FISHING) return;
         InputConstants.Key previewBind = KeyBindingHelper.getBoundKeyOf(minecraft.options.keyPickItem);
         if (keyCode == previewBind.getValue()) {
             ItemStack item = hoveredSlot.getItem();

--- a/src/main/java/net/asodev/islandutils/mixins/cosmetics/PreviewTutorialMixin.java
+++ b/src/main/java/net/asodev/islandutils/mixins/cosmetics/PreviewTutorialMixin.java
@@ -48,9 +48,8 @@ public class PreviewTutorialMixin {
             )
     )
     private void injectedTooltipLines(Item.TooltipContext tooltipContext, TooltipDisplay tooltipDisplay, @Nullable Player player, TooltipFlag tooltipFlag, Consumer<Component> consumer, CallbackInfo ci) {
+        if (!CosmeticState.shouldShowCosmeticPreview()) return;
         if (CosmeticState.getType((ItemStack) (Object) this) == null) return;
-        if (!IslandOptions.getCosmetics().isShowPlayerPreview()) return;
-        if (MccIslandState.getGame() != Game.HUB && MccIslandState.getGame() != Game.FISHING) return;
         consumer.accept(previewComponent);
     }
 

--- a/src/main/java/net/asodev/islandutils/mixins/cosmetics/UIMixin.java
+++ b/src/main/java/net/asodev/islandutils/mixins/cosmetics/UIMixin.java
@@ -34,11 +34,9 @@ public abstract class UIMixin extends AbstractContainerScreen<ChestMenu> {
 
     @Inject(method = "renderBg", at = @At("TAIL"))
     public void renderBg(GuiGraphics guiGraphics, float f, int i, int j, CallbackInfo ci) {
-        if (!MccIslandState.isOnline()) return;
-        if (MccIslandState.getGame() != Game.HUB && MccIslandState.getGame() != Game.FISHING) return;
+        if (!CosmeticState.shouldShowCosmeticPreview()) return;
 
         CosmeticsOptions options = IslandOptions.getCosmetics();
-        if (!options.isShowPlayerPreview()) return;
         boolean isCosmeticMenu = false;
         if (options.isShowOnOnlyCosmeticMenus() && !(isCosmeticMenu = CosmeticState.isCosmeticMenu(this))) return;
 

--- a/src/main/java/net/asodev/islandutils/modules/cosmetics/CosmeticState.java
+++ b/src/main/java/net/asodev/islandutils/modules/cosmetics/CosmeticState.java
@@ -1,5 +1,7 @@
 package net.asodev.islandutils.modules.cosmetics;
 
+import net.asodev.islandutils.options.IslandOptions;
+import net.asodev.islandutils.state.MccIslandState;
 import net.asodev.islandutils.util.Utils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
@@ -98,6 +100,15 @@ public class CosmeticState {
             if (type != null) return true;
         }
         return false;
+    }
+
+    public static boolean shouldShowCosmeticPreview() {
+        // don't show if we're not on mcci
+        if (!MccIslandState.isOnline()) return false;
+        // don't show if we have them disabled
+        if (!IslandOptions.getCosmetics().isShowPlayerPreview()) return false;
+        // if we have chosen to NOT show in games and we are in a game, disable. otherwise show!
+        return IslandOptions.getCosmetics().isShowInGames() || MccIslandState.getGame().isHubGame();
     }
 
     public static boolean itemsMatch(ItemStack item, ItemStack compare) {

--- a/src/main/java/net/asodev/islandutils/options/categories/CosmeticsOptions.java
+++ b/src/main/java/net/asodev/islandutils/options/categories/CosmeticsOptions.java
@@ -13,6 +13,7 @@ public class CosmeticsOptions implements OptionsCategory {
     boolean showPlayerPreview = true;
     boolean showOnHover = true;
     boolean showOnOnlyCosmeticMenus = true;
+    boolean showInGames = true;
 
     public boolean isShowPlayerPreview() {
         return showPlayerPreview;
@@ -24,6 +25,10 @@ public class CosmeticsOptions implements OptionsCategory {
 
     public boolean isShowOnOnlyCosmeticMenus() {
         return showOnOnlyCosmeticMenus;
+    }
+
+    public boolean isShowInGames() {
+        return showInGames;
     }
 
     @Override
@@ -43,11 +48,17 @@ public class CosmeticsOptions implements OptionsCategory {
                 .controller(TickBoxControllerBuilder::create)
                 .binding(defaults.showOnOnlyCosmeticMenus, () -> showOnOnlyCosmeticMenus, value -> this.showOnOnlyCosmeticMenus = value)
                 .build();
+        Option<Boolean> showInGamesOption = Option.<Boolean>createBuilder()
+                .name(Component.translatable("text.autoconfig.islandutils.option.showInGames"))
+                .controller(TickBoxControllerBuilder::create)
+                .binding(defaults.showInGames, () -> showInGames, value -> this.showInGames = value)
+                .build();
         return ConfigCategory.createBuilder()
                 .name(Component.translatable("text.autoconfig.islandutils.category.cosmetics"))
                 .option(showPreviewOption)
                 .option(showHoverOption)
                 .option(showInOnlyCosmeticMenu)
+                .option(showInGamesOption)
                 .build();
     }
 }

--- a/src/main/java/net/asodev/islandutils/state/Game.java
+++ b/src/main/java/net/asodev/islandutils/state/Game.java
@@ -50,6 +50,9 @@ public enum Game {
     public boolean hasTeamChat() {
         return hasTeamChat;
     }
+    public boolean isHubGame() {
+        return this == FISHING || this == HUB;
+    }
 
     public static ResourceLocation getMusicLocation(String name) {
         return ResourceLocation.fromNamespaceAndPath("island", "island.music." + name);

--- a/src/main/resources/assets/island/lang/en_us.json
+++ b/src/main/resources/assets/island/lang/en_us.json
@@ -24,6 +24,7 @@
   "text.autoconfig.islandutils.option.showPlayerPreview": "Show Cosmetic Previews",
   "text.autoconfig.islandutils.option.showOnHover": "Preview cosmetics on hover",
   "text.autoconfig.islandutils.option.showOnOnlyCosmeticMenus": "Show cosmetic preview only in Cosmetic Menus",
+  "text.autoconfig.islandutils.option.showInGames": "Show cosmetic preview in games",
 
   "text.autoconfig.islandutils.category.discord": "Discord Presence",
   "text.autoconfig.islandutils.group.presenceDisplayOptions": "Presence Display Options",


### PR DESCRIPTION
This PR adds cosmetic previews to the new weapon skins!

<img width="898" height="1282" alt="CleanShot 2025-12-15 at 1  56 13@2x" src="https://github.com/user-attachments/assets/4fac9c4e-1d97-43a2-8872-567a2656d91a" />

It also fixes a couple of issues that I've noticed when using IslandUtils. To be more specific:
- Cosmetic previews not disabling when middle clicking again on the previewed skin
- Fishing and PKW Dojo games not being correctly set due to MCCI Backend changes